### PR TITLE
Further Python 3 compatibility 

### DIFF
--- a/enaml/workbench/ui/workbench_window.enaml
+++ b/enaml/workbench/ui/workbench_window.enaml
@@ -32,4 +32,4 @@ enamldef WorkbenchWindow(MainWindow):
         Include:
             objects << window_model.menus
     Include:
-        objects << filter(None, [window_model.workspace.content])
+        objects << list(filter(None, [window_model.workspace.content]))

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     description='Declarative DSL for building rich user interfaces in Python',
     long_description=open('README.rst').read(),
     requires=['atom', 'PyQt', 'ply', 'kiwisolver'],
-    install_requires=['distribute', 'atom >= 0.3.8', 'kiwisolver >= 0.1.2', 'ply >= 3.4'],
+    install_requires=['setuptools', 'atom >= 0.3.8', 'kiwisolver >= 0.1.2', 'ply >= 3.4'],
     packages=find_packages(),
     package_data={
         'enaml.applib': ['*.enaml'],


### PR DESCRIPTION
Based on commit ca41ee8 (post Python 3.4 support, but pre PyQt5 support, as there is no PyQt5 conda package for Windows atm) I'm trying to enhance Python 3 compatibility:
- [x] replace outdated distutils dependency with setuptools
- [ ] fix 2to3 related list vs iterator bugs in .enaml  files 
  - [x] filter (one occurrence)
  - [x] map (no occurrence)
  - [ ] others?
- [ ] Python 3.4 ast grammar changes
  - [ ] ClassDef now requires a keywords argument (and perhaps others) (compare [ast 3.4](https://docs.python.org/3.4/library/ast.html) with [ast 2.7](https://docs.python.org/2.7/library/ast.html))
    I'm not sure how to fix that, do you know what to do here?
  - [ ] others?
- [ ] Python 3.5 compatibility (This is rather more complex, I think)
  - [x] update byteplay.py (SETUP_WITH is now split into two)
  - [ ] probably many more
