### PR TITLE
[WIP] Python 2/3 compatibilty

### DIFF
--- a/docs/source/examples/example_doc_generator.py
+++ b/docs/source/examples/example_doc_generator.py
@@ -15,7 +15,7 @@ Look for example enaml files with the line:
 Generate an rst file, then open the app and take a snapshot.
 
 """
-
+from __future__ import print_function
 import os
 os.environ['QT_API'] = 'pyqt'
 import shutil
@@ -29,18 +29,18 @@ from enaml.application import timed_call
 
 class SnapShot(Atom):
     """ Generate a snapshot of an enaml view.
-    
+
     """
-    
+
     #: The snapshot save path.
     path = Unicode()
-    
+
     #: The enaml view object.
     view = Value()
-        
+
     def _observe_view(self, change):
         """ Move window and allow it to draw before taking the snapshot.
-        
+
         """
         if change['type'] == 'create':
             self.view.initial_position = (10, 10)
@@ -49,7 +49,7 @@ class SnapShot(Atom):
 
     def snapshot(self):
         """ Take a snapshot of the window and close it.
-        
+
         """
         widget = self.view.proxy.widget
         framesize =  widget.window().frameSize()
@@ -73,7 +73,7 @@ def generate_example_doc(app, docs_path, script_path):
     script_name = os.path.basename(script_path)
     script_name = script_name[:script_name.find('.')]
     print('generating doc for %s' % script_name)
-    
+
     script_title = script_name.replace('_', ' ').title()
     script_image_name = 'ex_' + script_name + '.png'
     image_path = os.path.join(docs_path, 'images', script_image_name)
@@ -151,7 +151,7 @@ def main():
     docs_path = os.path.dirname(__file__)
     base_path = '../../../examples'
     base_path = os.path.realpath(os.path.join(docs_path, base_path))
-    
+
     enaml_cache_dir = os.path.join(docs_path, '__enamlcache__')
 
     for dirname, dirnames, filenames in os.walk(base_path):

--- a/enaml/applib/live_editor_model.py
+++ b/enaml/applib/live_editor_model.py
@@ -9,6 +9,8 @@ import linecache
 import traceback
 from types import ModuleType
 
+from future.builtins import int
+from future.utils import exec_
 from atom.api import Atom, Str, Typed, observe
 
 import enaml
@@ -31,7 +33,7 @@ def _fake_linecache(text, filename):
 
     """
     size = len(text)
-    mtime = 1343290295
+    mtime = int(1343290295)
     lines = text.splitlines()
     lines = [l + '\n' for l in lines]
     linecache.cache[filename] = size, mtime, lines, filename
@@ -176,7 +178,7 @@ class LiveEditorModel(Atom):
                 module = ModuleType(filename.rsplit('.', 1)[0])
                 module.__file__ = filename
                 namespace = module.__dict__
-                exec(code, namespace)
+                exec_(code, namespace)
                 model = namespace.get(self.model_item, lambda: None)()
                 self.compiled_model = model
                 self._model_module = module
@@ -209,7 +211,7 @@ class LiveEditorModel(Atom):
                 module.__file__ = filename
                 namespace = module.__dict__
                 with enaml.imports():
-                    exec(code, namespace)
+                    exec_(code, namespace)
                 view = namespace.get(self.view_item, lambda: None)()
                 if isinstance(view, Object) and 'model' in view.members():
                     view.model = self.compiled_model

--- a/enaml/colors.py
+++ b/enaml/colors.py
@@ -10,6 +10,7 @@
 """
 from colorsys import hls_to_rgb
 import re
+from past.builtins import basestring
 
 from atom.api import Coerced
 
@@ -346,7 +347,7 @@ def coerce_color(color):
     """ The coercing function for the ColorMember.
 
     """
-    if isinstance(color, str):
+    if isinstance(color, basestring):
         return parse_color(color)
 
 

--- a/enaml/core/declarative.py
+++ b/enaml/core/declarative.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from future.utils import with_metaclass
+
 from atom.api import Event, Typed, Unicode
 from atom.datastructures.api import sortedmap
 
@@ -69,7 +71,7 @@ def d_func(func):
 INITIALIZED_FLAG = next(flag_generator)
 
 
-class Declarative(Object, metaclass=DeclarativeMeta):
+class Declarative(with_metaclass(DeclarativeMeta, Object)):
     """ The most base class of the Enaml declarative objects.
 
     This class provides the core functionality required of declarative

--- a/enaml/core/enaml_compiler.py
+++ b/enaml/core/enaml_compiler.py
@@ -166,10 +166,10 @@ class EnamlCompiler(cmn.CompilerBase):
         """
         assert isinstance(node, Module), 'invalid node'
 
-        # Protect against unicode filenames, which are incompatible
+        # On Python 2 protect against unicode filenames, which are incompatible
         # with code objects created via types.CodeType
-        #if isinstance(filename, str):
-        #    filename = filename.encode(sys.getfilesystemencoding())
+        if sys.version_info[0] == 3 and isinstance(filename, type(u'')):
+            filename = filename.encode(sys.getfilesystemencoding())
 
         # Create the compiler and generate the code.
         compiler = cls(filename=filename)

--- a/enaml/core/import_hooks.py
+++ b/enaml/core/import_hooks.py
@@ -14,6 +14,8 @@ import struct
 import sys
 import types
 
+from future.utils import with_metaclass, exec_
+
 from .enaml_compiler import EnamlCompiler, COMPILER_VERSION
 from .parser import parse
 
@@ -75,7 +77,7 @@ class abstractclassmethod(classmethod):
 #------------------------------------------------------------------------------
 # Abstract Enaml Importer
 #------------------------------------------------------------------------------
-class AbstractEnamlImporter(object, metaclass=ABCMeta):
+class AbstractEnamlImporter(with_metaclass(ABCMeta, object)):
     """ An abstract base class which defines the api required to
     implement an Enaml importer.
 
@@ -142,7 +144,7 @@ class AbstractEnamlImporter(object, metaclass=ABCMeta):
         # module code of an Enaml file.
         try:
             with imports():
-                exec(code, mod.__dict__)
+                exec_(code, mod.__dict__)
         except Exception:
             if not pre_exists:
                 del sys.modules[fullname]

--- a/enaml/core/standard_tracer.py
+++ b/enaml/core/standard_tracer.py
@@ -5,6 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from past.builtins import basestring
 from atom.api import Atom, atomref
 
 from .alias import Alias
@@ -157,7 +158,7 @@ class StandardTracer(CodeTracer):
         nkwargs = (argspec >> 8) & 0xFF
         if (func is getattr and (nargs == 2 or nargs == 3) and nkwargs == 0):
             obj, attr = argtuple[0], argtuple[1]
-            if isinstance(obj, Atom) and isinstance(attr, str):
+            if isinstance(obj, Atom) and isinstance(attr, basestring):
                 self.trace_atom(obj, attr)
 
     def return_value(self, value):

--- a/enaml/fonts.py
+++ b/enaml/fonts.py
@@ -8,6 +8,8 @@
 """ A utility module for dealing with CSS3 font strings.
 
 """
+from past.builtins import basestring
+
 from atom.api import Coerced
 
 from .fontext import Font, FontStyle, FontCaps
@@ -174,7 +176,7 @@ def coerce_font(font):
     """ The coercing function for the FontMember.
 
     """
-    if isinstance(font, str):
+    if isinstance(font, basestring):
         return parse_font(font)
 
 

--- a/enaml/layout/constrainable.py
+++ b/enaml/layout/constrainable.py
@@ -7,12 +7,13 @@
 #------------------------------------------------------------------------------
 from abc import ABCMeta
 
+from future.utils import with_metaclass
 from atom.api import Atom, Constant, DefaultValue, Enum
 
 import kiwisolver as kiwi
 
 
-class Constrainable(object, metaclass=ABCMeta):
+class Constrainable(with_metaclass(ABCMeta, object)):
     """ An abstract base class for defining constrainable objects.
 
     Implementations must provide `top`, `bottom`, `left`, `right`,

--- a/enaml/layout/dock_layout.py
+++ b/enaml/layout/dock_layout.py
@@ -9,6 +9,8 @@ from collections import deque
 import sys
 import warnings
 
+from future.utils import with_metaclass
+from past.builtins import basestring
 from atom.api import Atom, Int, Bool, Coerced, Enum, List, Unicode
 
 from enaml.nodevisitor import NodeVisitor
@@ -172,13 +174,13 @@ class _SplitLayoutItemMeta(type):
         return isinstance(instance, (ItemLayout, TabLayout, SplitLayout))
 
     def __call__(cls, item):
-        if isinstance(item, str):
+        if isinstance(item, basestring):
             return ItemLayout(item)
         msg = "cannot coerce '%s' to a 'SplitLayout' item"
         raise TypeError(msg % type(item).__name__)
 
 
-class _SplitLayoutItem(metaclass=_SplitLayoutItemMeta):
+class _SplitLayoutItem(with_metaclass(_SplitLayoutItemMeta, object)):
     """ A private class which performs type checking for split layouts.
 
     """
@@ -199,7 +201,7 @@ class SplitLayout(LayoutNode):
     items = List(Coerced(_SplitLayoutItem))
 
     def __init__(self, *items, **kwargs):
-        super().__init__(items=list(items), **kwargs)
+        super(SplitLayout, self).__init__(items=list(items), **kwargs)
 
     def children(self):
         """ Get the list of children of the split layout.
@@ -223,7 +225,7 @@ class VSplitLayout(SplitLayout):
     """
     def __init__(self, *items, **kwargs):
         kwargs['orientation'] = 'vertical'
-        super().__init__(*items, **kwargs)
+        super(VSplitLayout, self).__init__(*items, **kwargs)
 
 
 class DockBarLayout(LayoutNode):
@@ -252,13 +254,13 @@ class _AreaLayoutItemMeta(type):
         return isinstance(instance, allowed)
 
     def __call__(cls, item):
-        if isinstance(item, str):
+        if isinstance(item, basestring):
             return ItemLayout(item)
         msg = "cannot coerce '%s' to an 'AreaLayout' item"
         raise TypeError(msg % type(item).__name__)
 
 
-class _AreaLayoutItem(object, metaclass=_AreaLayoutItemMeta):
+class _AreaLayoutItem(with_metaclass(_AreaLayoutItemMeta, object)):
     """ A private class which performs type checking for area layouts.
 
     """
@@ -306,14 +308,14 @@ class _DockLayoutItemMeta(type):
         return isinstance(instance, (ItemLayout, AreaLayout))
 
     def __call__(cls, item):
-        if isinstance(item, str):
+        if isinstance(item, basestring):
             return ItemLayout(item)
         if isinstance(item, (SplitLayout, TabLayout)):
             return AreaLayout(item)
         msg = "cannot coerce '%s' to a 'DockLayout' item"
         raise TypeError(msg % type(item).__name__)
 
-class _DockLayoutItem(metaclass=_DockLayoutItemMeta):
+class _DockLayoutItem(with_metaclass(_DockLayoutItemMeta, object)):
     """ A private class which performs type checking for dock layouts.
 
     """

--- a/enaml/layout/linear_symbolic.py
+++ b/enaml/layout/linear_symbolic.py
@@ -7,10 +7,12 @@
 #------------------------------------------------------------------------------
 from abc import ABCMeta
 
+
+from future.utils import with_metaclass
 import kiwisolver as kiwi
 
 
-class LinearSymbolic(object, metaclass=ABCMeta):
+class LinearSymbolic(with_metaclass(ABCMeta, object)):
     """ An abstract base class for testing linear symbolic interfaces.
 
     """

--- a/enaml/layout/strength_member.py
+++ b/enaml/layout/strength_member.py
@@ -5,6 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from future.builtins import int
 from atom.api import Validate, Value
 
 

--- a/enaml/runner.py
+++ b/enaml/runner.py
@@ -8,10 +8,14 @@
 """ Command-line tool to run .enaml files.
 
 """
+from __future__ import print_function
+
 import optparse
 import os
 import sys
 import types
+
+from future.utils import exec_
 
 from enaml import imports
 from enaml.core.parser import parse
@@ -55,7 +59,7 @@ def main():
     # Bung in the command line arguments.
     sys.argv = [enaml_file] + script_argv
     with imports():
-        exec(code, ns)
+        exec_(code, ns)
 
     requested = options.component
     if requested in ns:

--- a/enaml/src/declfunction.cpp
+++ b/enaml/src/declfunction.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <sstream>
 #include "pythonhelpersex.h"
+#include "py23compat.h"
 
 
 using namespace PythonHelpers;
@@ -153,7 +154,15 @@ PyTypeObject DFunc_Type = {
     (printfunc)0,                           /* tp_print */
     (getattrfunc)0,                         /* tp_getattr */
     (setattrfunc)0,                         /* tp_setattr */
-    0,                                      /* tp_reserved */
+#if PY_MAJOR_VERSION >= 3
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                  /* tp_as_async */
+#else
+	( void* ) 0,                           /* tp_reserved */
+#endif
+#else
+	( cmpfunc )0,                          /* tp_compare */
+#endif
     (reprfunc)DFunc_repr,                   /* tp_repr */
     (PyNumberMethods*)0,                    /* tp_as_number */
     (PySequenceMethods*)0,                  /* tp_as_sequence */

--- a/enaml/src/funchelper.cpp
+++ b/enaml/src/funchelper.cpp
@@ -6,6 +6,7 @@
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
 #include <Python.h>
+#include "py23compat.h"
 
 
 extern "C" {
@@ -84,6 +85,7 @@ call_func( PyObject* mod, PyObject* args )
         /* XXX This is broken if the caller deletes dict items! */
     }
 
+#if PY_MAJOR_VERSION >= 3
     PyObject* result = PyEval_EvalCodeEx(
         PyFunction_GET_CODE( func ),
         PyFunction_GET_GLOBALS( func ),
@@ -93,6 +95,17 @@ call_func( PyObject* mod, PyObject* args )
         keywords, num_keywords, defaults, num_defaults,
         NULL, PyFunction_GET_CLOSURE( func )
     );
+#else
+    PyObject* result = PyEval_EvalCodeEx(
+        reinterpret_cast<PyCodeObject*>( PyFunction_GET_CODE( func ) ),
+        PyFunction_GET_GLOBALS( func ),
+        func_locals,
+        &PyTuple_GET_ITEM( func_args, 0 ),
+        PyTuple_Size( func_args ),
+        keywords, num_keywords, defaults, num_defaults,
+        PyFunction_GET_CLOSURE( func )
+        );
+#endif
 
     if( keywords )
         PyMem_DEL( keywords );
@@ -104,12 +117,6 @@ struct module_state {
     PyObject *error;
 };
 
-#if PY_MAJOR_VERSION >= 3
-#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
-#else
-#define GETSTATE(m) (&_state)
-static struct module_state _state;
-#endif
 
 static PyMethodDef
 funchelper_methods[] = {
@@ -118,8 +125,9 @@ funchelper_methods[] = {
     { 0 } // sentinel
 };
 
-
 #if PY_MAJOR_VERSION >= 3
+
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
 
 static int funchelper_traverse(PyObject *m, visitproc visit, void *arg) {
     Py_VISIT(GETSTATE(m)->error);
@@ -144,17 +152,14 @@ static struct PyModuleDef moduledef = {
         NULL
 };
 
-#define INITERROR return NULL
-
-PyMODINIT_FUNC
-PyInit_funchelper(void)
-
 #else
-#define INITERROR return
 
-PyMODINIT_FUNC
-initfunchelper(void)
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+
 #endif
+
+MOD_INIT_FUNC(funchelper)
 {
 #if PY_MAJOR_VERSION >= 3
     PyObject *mod = PyModule_Create(&moduledef);

--- a/enaml/src/py23compat.h
+++ b/enaml/src/py23compat.h
@@ -1,0 +1,56 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+#pragma once
+
+#include <Python.h>
+
+#if PY_MAJOR_VERSION >= 3
+
+#define Py23Str_Check PyUnicode_Check
+#define Py23Str_CheckExact PyUnicode_CheckExact
+#define Py23Str_AS_STRING PyUnicode_AsUTF8
+#define Py23Str_FromString PyUnicode_FromString
+#define Py23Str_InternFromString PyUnicode_InternFromString
+#define Py23Str_InternInPlace PyUnicode_InternInPlace
+#define Py23Str_FromFormat PyUnicode_FromFormat
+#define Py23Bytes_Check PyBytes_Check
+#define Py23Bytes_AS_STRING PyBytes_AS_STRING
+#define Py23Bytes_FromStringAndSize PyBytes_FromStringAndSize
+#define Py23Int_Check PyLong_Check
+#define Py23Int_FromLong PyLong_FromLong
+#define Py23Int_AsLong PyLong_AsLong
+#define Py23Number_Int PyNumber_Long
+#define Py23Int_AsSsize_t PyLong_AsSsize_t
+#define Py23Int_FromSsize_t PyLong_FromSsize_t
+
+#define INITERROR return NULL
+#define MOD_INIT_FUNC(name) PyMODINIT_FUNC PyInit_##name(void)
+
+#else
+
+#define Py23Str_Check PyString_Check
+#define Py23Str_CheckExact PyString_CheckExact
+#define Py23Str_AS_STRING PyString_AS_STRING
+#define Py23Str_FromString PyString_FromString
+#define Py23Str_InternFromString PyString_InternFromString
+#define Py23Str_InternInPlace PyString_InternInPlace
+#define Py23Str_FromFormat PyString_FromFormat
+#define Py23Bytes_Check PyString_Check
+#define Py23Bytes_AS_STRING PyString_AS_STRING
+#define Py23Bytes_FromStringAndSize PyString_FromStringAndSize
+#define Py23Int_Check( ob ) ( PyInt_Check( ob ) || PyLong_Check( ob ) )
+#define Py23Int_FromLong PyInt_FromLong
+#define Py23Int_AsLong PyInt_AsLong
+#define Py23Number_Int PyNumber_Int
+#define Py23Int_AsSsize_t PyInt_AsSsize_t
+#define Py23Int_FromSsize_t PyInt_FromSsize_t
+
+#define INITERROR return
+#define MOD_INIT_FUNC(name) PyMODINIT_FUNC init##name(void)
+
+#endif

--- a/enaml/src/weakmethod.cpp
+++ b/enaml/src/weakmethod.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <sstream>
 #include "pythonhelpers.h"
+#include "py23compat.h"
 
 
 using namespace PythonHelpers;
@@ -194,7 +195,11 @@ WeakMethod_call( WeakMethod* self, PyObject* args, PyObject* kwargs )
     PyObjectPtr mself( selfref.get_object() );
     if( mself.is_None() )
         Py_RETURN_NONE;
+#if PY_MAJOR_VERSION >= 3
     PyMethodPtr method( PyMethod_New( self->func, mself.get() ) );
+#else
+    PyMethodPtr method( PyMethod_New( self->func, mself.get(), self->cls ) );
+#endif
     if( !method )
         return 0;
     PyTuplePtr argsptr( args, true );
@@ -250,7 +255,15 @@ PyTypeObject WeakMethod_Type = {
     (printfunc)0,                           /* tp_print */
     (getattrfunc)0,                         /* tp_getattr */
     (setattrfunc)0,                         /* tp_setattr */
-    0,                                      /* tp_reserved */
+#if PY_MAJOR_VERSION >= 3
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                  /* tp_as_async */
+#else
+	( void* ) 0,                           /* tp_reserved */
+#endif
+#else
+	( cmpfunc )0,                          /* tp_compare */
+#endif
     (reprfunc)0,                            /* tp_repr */
     (PyNumberMethods*)0,                    /* tp_as_number */
     (PySequenceMethods*)0,                  /* tp_as_sequence */
@@ -294,12 +307,6 @@ struct module_state {
     PyObject *error;
 };
 
-#if PY_MAJOR_VERSION >= 3
-#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
-#else
-#define GETSTATE(m) (&_state)
-static struct module_state _state;
-#endif
 
 static PyMethodDef
 weakmethod_methods[] = {
@@ -307,6 +314,8 @@ weakmethod_methods[] = {
 };
 
 #if PY_MAJOR_VERSION >= 3
+
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
 
 static int weakmethod_traverse(PyObject *m, visitproc visit, void *arg) {
     Py_VISIT(GETSTATE(m)->error);
@@ -331,17 +340,14 @@ static struct PyModuleDef moduledef = {
         NULL
 };
 
-#define INITERROR return NULL
-
-PyMODINIT_FUNC
-PyInit_weakmethod(void)
-
 #else
-#define INITERROR return
 
-PyMODINIT_FUNC
-initweakmethod(void)
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+
 #endif
+
+MOD_INIT_FUNC(weakmethod)
 {
 #if PY_MAJOR_VERSION >= 3
     PyObject *mod = PyModule_Create(&moduledef);
@@ -354,7 +360,7 @@ initweakmethod(void)
     if( !weak_methods )
         INITERROR;
 
-    remove_str = PyUnicode_FromString( "_remove" );
+    remove_str = Py23Str_FromString( "_remove" );
     if( !remove_str )
         INITERROR;
 

--- a/enaml/stdlib/dock_area_styles.enaml
+++ b/enaml/stdlib/dock_area_styles.enaml
@@ -14,6 +14,8 @@ developer is free to define their own styles completely from scratch, and
 ignore these styles in their entirety.
 
 """
+from future.builtins import str
+from past.builtins import basestring
 from atom.api import Atom, Typed, Unicode
 from enaml.core.template_ import Template
 from enaml.styling import StyleSheet, Style, Setter
@@ -719,11 +721,11 @@ def register_styles(name, styles):
         This will be raised the name is already registered.
 
     """
-    assert isinstance(name, str)
+    assert isinstance(name, basestring)
     assert isinstance(styles, Template)
     if name in __STYLE_REGISTRY:
         raise ValueError("The '%s' name is already registered." % name)
-    __STYLE_REGISTRY[name] = styles
+    __STYLE_REGISTRY[str(name)] = styles
 
 
 def get_registered_styles(name):

--- a/enaml/stdlib/fields.enaml
+++ b/enaml/stdlib/fields.enaml
@@ -10,6 +10,7 @@
 This is a library of Enaml components deriving from the builtin Field.
 
 """
+from future.builtins import str
 from enaml.validator import RegexValidator, IntValidator, FloatValidator
 from enaml.widgets.field import Field
 

--- a/enaml/styling.py
+++ b/enaml/styling.py
@@ -8,6 +8,8 @@
 """ Declarative classes which implement style sheet styling.
 
 """
+from __future__ import unicode_literals
+
 from collections import defaultdict
 
 from atom.api import Atom, Unicode, Typed, observe

--- a/enaml/widgets/combo_box.py
+++ b/enaml/widgets/combo_box.py
@@ -5,8 +5,9 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
 from atom.api import (
-    Bool, List, Int, Property, Str, Typed, ForwardTyped, set_default,
+    Bool, List, Int, Property, Unicode, Typed, ForwardTyped, set_default,
     observe
 )
 
@@ -41,7 +42,7 @@ class ComboBox(Control):
 
     """
     #: The strings to display in the combo box.
-    items = d_(List(Str()))
+    items = d_(List(Unicode()))
 
     #: The integer index of the currently selected item. If the index
     #: falls outside the range of items, the item will be deselected.

--- a/enaml/widgets/field.py
+++ b/enaml/widgets/field.py
@@ -6,7 +6,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import (
-    Bool, Int, Str, Enum, List, Typed, ForwardTyped, observe, set_default
+    Bool, Int, Unicode, Enum, List, Typed, ForwardTyped, observe, set_default
 )
 
 from enaml.core.declarative import d_
@@ -52,7 +52,7 @@ class Field(Control):
 
     """
     #: The text to display in the field.
-    text = d_(Str())
+    text = d_(Unicode())
 
     #: The mask to use for text input:
     #:  http://qt-project.org/doc/qt-4.8/qlineedit.html#inputMask-prop
@@ -81,7 +81,7 @@ class Field(Control):
     #: The mask consists of a string of mask characters and separators, optionally
     #: followed by a semicolon and the character used for blanks
     #: Eg: 9 digit phone number: (999) 999-9999;_
-    mask = d_(Str())
+    mask = d_(Unicode())
 
     #: The validator to use for this field. If the validator provides
     #: a client side validator, then text will only be submitted if it
@@ -100,7 +100,7 @@ class Field(Control):
 
     #: The grayed-out text to display if the field is empty and the
     #: widget doesn't have focus. Defaults to the empty string.
-    placeholder = d_(Str())
+    placeholder = d_(Unicode())
 
     #: How to display the text in the field. Valid values are 'normal'
     #: which displays the text as normal, 'password' which displays the

--- a/enaml/widgets/file_dialog.py
+++ b/enaml/widgets/file_dialog.py
@@ -5,6 +5,9 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
+from future.builtins import str
 from atom.api import (
     Enum, Bool, Callable, List, Unicode, Typed, ForwardTyped, Event
 )

--- a/enaml/widgets/file_dialog_ex.py
+++ b/enaml/widgets/file_dialog_ex.py
@@ -5,6 +5,9 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+
+from __future__ import unicode_literals
+
 from atom.api import Bool, Enum, List, Unicode, Typed, ForwardTyped, observe
 
 from enaml.core.declarative import d_

--- a/enaml/widgets/label.py
+++ b/enaml/widgets/label.py
@@ -6,7 +6,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import (
-    Typed, ForwardTyped, Str, Enum, Event, observe, set_default
+    Typed, ForwardTyped, Unicode, Enum, Event, observe, set_default
 )
 
 from enaml.core.declarative import d_
@@ -36,7 +36,7 @@ class Label(Control):
 
     """
     #: The str text for the label.
-    text = d_(Str())
+    text = d_(Unicode())
 
     #: The horizontal alignment of the text in the widget area.
     align = d_(Enum('left', 'right', 'center', 'justify'))

--- a/enaml/widgets/multiline_field.py
+++ b/enaml/widgets/multiline_field.py
@@ -5,7 +5,9 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Typed, ForwardTyped, Str, observe, set_default
+from __future__ import unicode_literals
+
+from atom.api import Bool, Typed, ForwardTyped, Unicode, observe, set_default
 
 from enaml.core.declarative import d_
 
@@ -40,7 +42,7 @@ class MultilineField(Control):
 
     """
     #: The str text to display in the field.
-    text = d_(Str())
+    text = d_(Unicode())
 
     #: Whether or not the field is read only.
     read_only = d_(Bool(False))

--- a/enaml/widgets/object_combo.py
+++ b/enaml/widgets/object_combo.py
@@ -5,6 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from future.builtins import str
 from atom.api import (
     Bool, Callable, List, Value, Typed, ForwardTyped, set_default, observe
 )

--- a/enaml/workbench/core/core_plugin.py
+++ b/enaml/workbench/core/core_plugin.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
 from collections import defaultdict
 
 from atom.api import Typed

--- a/enaml/workbench/extension.py
+++ b/enaml/workbench/extension.py
@@ -5,6 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
 from atom.api import Callable, Int, Unicode
 
 from enaml.core.declarative import Declarative, d_

--- a/enaml/workbench/extension_point.py
+++ b/enaml/workbench/extension_point.py
@@ -5,6 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
 from atom.api import Tuple, Unicode
 
 from enaml.core.declarative import Declarative, d_

--- a/enaml/workbench/ui/menu_helper.py
+++ b/enaml/workbench/ui/menu_helper.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
 from collections import defaultdict
 
 from atom.api import Atom, Instance, List, Typed

--- a/enaml/workbench/ui/ui_plugin.py
+++ b/enaml/workbench/ui/ui_plugin.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
 from atom.api import Typed
 
 from enaml.application import Application

--- a/enaml/workbench/ui/ui_workbench.py
+++ b/enaml/workbench/ui/ui_workbench.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
 from enaml.workbench.workbench import Workbench
 
 

--- a/enaml/workbench/workbench.py
+++ b/enaml/workbench/workbench.py
@@ -7,6 +7,7 @@
 #------------------------------------------------------------------------------
 from collections import defaultdict
 
+from future.builtins import str
 from atom.api import Atom, Event, Typed
 
 from .plugin import Plugin

--- a/examples/aliases/chained_attribute_alias.enaml
+++ b/examples/aliases/chained_attribute_alias.enaml
@@ -13,6 +13,7 @@ exposing individual attributes instead of entire widgets.
 
 << autodoc-me >>
 """
+from future.builtins import str
 from enaml.widgets.api import Window, Container, Slider, Field, GroupBox
 
 

--- a/examples/aliases/chained_widget_alias.enaml
+++ b/examples/aliases/chained_widget_alias.enaml
@@ -9,6 +9,7 @@
 
 << autodoc-me >>
 """
+from future.builtins import str
 from enaml.widgets.api import Window, Container, Slider, Field, GroupBox
 
 

--- a/examples/tutorial/employee/employee.py
+++ b/examples/tutorial/employee/employee.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import print_function
+
 import datetime
 
 from atom.api import Atom, Unicode, Range, Bool, Value, Int, Tuple, observe

--- a/examples/tutorial/employee/phone_validator.py
+++ b/examples/tutorial/employee/phone_validator.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
 import re
 
 from enaml.validator import Validator

--- a/examples/tutorial/person/person.py
+++ b/examples/tutorial/person/person.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
 from atom.api import Atom, Unicode, Range, Bool, observe
 
 import enaml

--- a/examples/widgets/file_dialog.enaml
+++ b/examples/widgets/file_dialog.enaml
@@ -9,6 +9,10 @@
 
 << autodoc-me >>
 """
+from __future__ import unicode_literals
+
+from future.builtins import str
+
 from enaml.layout.api import hbox, align
 from enaml.widgets.api import (
     Container, Field, FileDialogEx, Label, PushButton, Window

--- a/examples/workbench/persistent_workspace.py
+++ b/examples/workbench/persistent_workspace.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import print_function
+
 import pickle
 
 from atom.api import Unicode

--- a/examples/workbench/sample_workspace.py
+++ b/examples/workbench/sample_workspace.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import print_function
+
 from atom.api import Subclass, Unicode
 
 from enaml.widgets.api import Container

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class BuildExt(build_ext):
     }
 
     def initialize_options(self):
-        super().initialize_options()
+        build_ext.initialize_options(self)
         self.debug = False
 
     def build_extensions(self):
@@ -94,7 +94,8 @@ setup(
     description='Declarative DSL for building rich user interfaces in Python',
     long_description=open('README.rst').read(),
     requires=['atom', 'PyQt', 'ply', 'kiwisolver'],
-    install_requires=['setuptools', 'atom >= 0.3.8', 'kiwisolver >= 0.1.2', 'ply >= 3.4'],
+    install_requires=['setuptools', 'future', 'atom >= 0.3.8',
+                      'kiwisolver >= 0.1.2', 'ply >= 3.4'],
     packages=find_packages(),
     package_data={
         'enaml.applib': ['*.enaml'],

--- a/tests/test_stylesheet.py
+++ b/tests/test_stylesheet.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
 from textwrap import dedent
 
 from utils import compile_source

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from future.utils import exec_
+
 from enaml.core.enaml_compiler import EnamlCompiler
 from enaml.core.parser import parse
 
@@ -33,5 +35,5 @@ def compile_source(source, item, filename='<test>'):
     ast = parse(source, filename)
     code = EnamlCompiler.compile(ast, filename)
     namespace = {}
-    exec(code, namespace)
+    exec_(code, namespace)
     return namespace[item]


### PR DESCRIPTION
So far this PR deals with : 
- make the cpp src files compatible under both python 2 and 3
- fix use of metaclass using the future package
- fix use of basestring using future
- fix use of str (when previously unicode was used)
- import of print_function, unicode_literals when appropriate (I would favor making all __future__ imports systematic)

I left untouched qt backends related files so far. And code generation files also as those require more discussions I think.
